### PR TITLE
Changed visibility of menu in browser window

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,12 +11,16 @@ function createWindow () {
     height: config.height,
     // transparent:true,
     // frame:false,
-    titleBarStyle: 'hidden',
+    // titleBarStyle: 'hidden',
     alwaysOnTop: true,
     webPreferences: {
       nodeIntegration: true
     },
   })
+  
+  //Remove Menu
+  win.setMenuBarVisibility(false)
+  //or = win.setMenu(null) if setMenuBarVisibility doesn't work
 
   win.loadURL(config.url)
 


### PR DESCRIPTION
The property 'titleBarStyle: 'hidden' removes the options to maximize, minimize and close the window on some operating systems. After some research I found out that's more convenient to use "setMenuBarVisibility" function to do it. Hope you like it ;)