### PR TITLE
fix: dimensions should be of type number

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    width: "600",
-    height: "400",
+    width: 600,
+    height: 400,
     url: "http://localhost:3000/"
 }


### PR DESCRIPTION
Opa, percebi isso há um tempo já quando eu tava querendo mexer com responsividade num app web... Como vi que teve update nesse repo recentemente, achei que valesse a pena fazer esse PR.

Falhei inúmeras vezes ao tentar trocar as dimensões da janela criada pelo Electron e, só depois de muita pesquisa, entendi que as dimensões em string não funcionam. Mudei pra number e funfou :)